### PR TITLE
Refactor admin routes and update navigation links to use /admin prefix

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -17,7 +17,7 @@ import AppLogoIcon from './app-logo-icon';
 const mainNavItems: NavItem[] = [
     {
         title: 'Dashboard',
-        href: '/dashboard',
+        href: '/admin/dashboard',
         icon: LayoutGrid,
     },
 ];
@@ -64,7 +64,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                         </Sheet>
                     </div>
 
-                    <Link href="/dashboard" prefetch className="flex items-center space-x-2">
+                    <Link href="/admin/dashboard" prefetch className="flex items-center space-x-2">
                         <AppLogo />
                     </Link>
 

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -9,42 +9,42 @@ import AppLogo from './app-logo';
 const mainNavItems: NavItem[] = [
     {
         title: 'Dashboard',
-        href: '/dashboard',
+        href: '/admin/dashboard',
         icon: LayoutGrid,
     },
     {
         title: 'Admin Management',
-        href: '/admins',
+        href: '/admin/admins',
         icon: Users,
     },
     {
         title: 'About Us',
-        href: '/about-us',
+        href: '/admin/about-us',
         icon: Newspaper,
     },
     {
         title: 'News',
-        href: '/news',
+        href: '/admin/news',
         icon: Newspaper,
     },
     {
         title: 'Journal',
-        href: '/journal',
+        href: '/admin/journal',
         icon: Journal,
     },
     {
         title: 'Events',
-        href: '/events',
+        href: '/admin/events',
         icon: Calendar,
     },
     {
         title: 'Conferences',
-        href: '/conferences',
+        href: '/admin/conferences',
         icon: Video,
     },
     {
         title: 'Careers',
-        href: '/careers', // Tetap /careers
+        href: '/admin/careers', // Tetap /careers
         icon: GraduationCap,
     },
 ];
@@ -56,7 +56,7 @@ export function AppSidebar() {
                 <SidebarMenu>
                     <SidebarMenuItem>
                         <SidebarMenuButton size="lg" asChild>
-                            <Link href="/dashboard" prefetch>
+                            <Link href="/admin/dashboard" prefetch>
                                 <AppLogo />
                             </Link>
                         </SidebarMenuButton>

--- a/resources/js/pages/admin/about-us/index.tsx
+++ b/resources/js/pages/admin/about-us/index.tsx
@@ -35,8 +35,8 @@ interface AboutUsIndexProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'About Us Management', href: '/about-us' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'About Us Management', href: '/admin/about-us' },
 ];
 
 export default function AboutUsIndex({ aboutUs, admins, success }: AboutUsIndexProps) {

--- a/resources/js/pages/admin/admins/create.tsx
+++ b/resources/js/pages/admin/admins/create.tsx
@@ -9,9 +9,9 @@ import { ArrowLeft } from 'lucide-react';
 import { FormEventHandler } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Admin Management', href: '/admins' },
-    { title: 'Create Admin', href: '/admins/create' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Admin Management', href: '/admin/admins' },
+    { title: 'Create Admin', href: '/admin/admins/create' },
 ];
 
 export default function AdminCreate() {
@@ -34,7 +34,7 @@ export default function AdminCreate() {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/admins">
+                    <Link href="/admin/admins">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="mr-2 h-4 w-4" />
                             Back to Admins
@@ -117,7 +117,7 @@ export default function AdminCreate() {
                                 <Button type="submit" disabled={processing}>
                                     {processing ? 'Creating...' : 'Create Admin'}
                                 </Button>
-                                <Link href="/admins">
+                                <Link href="/admin/admins">
                                     <Button variant="outline" type="button">
                                         Cancel
                                     </Button>

--- a/resources/js/pages/admin/admins/edit.tsx
+++ b/resources/js/pages/admin/admins/edit.tsx
@@ -21,8 +21,8 @@ interface AdminEditProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Admin Management', href: '/admins' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Admin Management', href: '/admin/admins' },
     { title: 'Edit Admin', href: '#' },
 ];
 
@@ -46,7 +46,7 @@ export default function AdminEdit({ admin }: AdminEditProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/admins">
+                    <Link href="/admin/admins">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="mr-2 h-4 w-4" />
                             Back to Admins
@@ -145,7 +145,7 @@ export default function AdminEdit({ admin }: AdminEditProps) {
                                 <Button type="submit" disabled={processing}>
                                     {processing ? 'Updating...' : 'Update Admin'}
                                 </Button>
-                                <Link href="/admins">
+                                <Link href="/admin/admins">
                                     <Button variant="outline" type="button">
                                         Cancel
                                     </Button>

--- a/resources/js/pages/admin/admins/index.tsx
+++ b/resources/js/pages/admin/admins/index.tsx
@@ -28,14 +28,14 @@ interface AdminIndexProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Admin Management', href: '/admins' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Admin Management', href: '/admin/admins' },
 ];
 
 export default function AdminIndex({ admins, success }: AdminIndexProps) {
     const handleDelete = (admin: Admin) => {
         if (confirm(`Are you sure you want to delete admin ${admin.username}?`)) {
-            router.delete(`/admins/${admin.id_admin}`);
+            router.delete(`/admin/admins/${admin.id_admin}`);
         }
     };
 
@@ -50,7 +50,7 @@ export default function AdminIndex({ admins, success }: AdminIndexProps) {
                         <h1 className="text-2xl font-bold tracking-tight">Admin Management</h1>
                         <p className="text-muted-foreground">Manage system administrators and their permissions</p>
                     </div>
-                    <Link href="/admins/create">
+                    <Link href="/admin/admins/create">
                         <Button>
                             <Plus className="mr-2 h-4 w-4" />
                             Add Admin
@@ -107,12 +107,12 @@ export default function AdminIndex({ admins, success }: AdminIndexProps) {
                                                 <td className="px-6 py-4">{new Date(admin.created_at).toLocaleDateString()}</td>
                                                 <td className="px-6 py-4">
                                                     <div className="flex items-center gap-2">
-                                                        <Link href={`/admins/${admin.id_admin}`}>
+                                                        <Link href={`/admin/admins/${admin.id_admin}`}>
                                                             <Button variant="ghost" size="sm">
                                                                 <Eye className="h-4 w-4" />
                                                             </Button>
                                                         </Link>
-                                                        <Link href={`/admins/${admin.id_admin}/edit`}>
+                                                        <Link href={`/admin/admins/${admin.id_admin}/edit`}>
                                                             <Button variant="ghost" size="sm">
                                                                 <Edit className="h-4 w-4" />
                                                             </Button>

--- a/resources/js/pages/admin/admins/show.tsx
+++ b/resources/js/pages/admin/admins/show.tsx
@@ -19,15 +19,15 @@ interface AdminShowProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Admin Management', href: '/admins' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Admin Management', href: '/admin/admins' },
     { title: 'Admin Details', href: '#' },
 ];
 
 export default function AdminShow({ admin }: AdminShowProps) {
     const handleDelete = () => {
         if (confirm(`Are you sure you want to delete admin ${admin.username}?`)) {
-            router.delete(`/admins/${admin.id_admin}`);
+            router.delete(`/admin/admins/${admin.id_admin}`);
         }
     };
 
@@ -39,7 +39,7 @@ export default function AdminShow({ admin }: AdminShowProps) {
                 {/* Header */}
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-4">
-                        <Link href="/admins">
+                        <Link href="/admin/admins">
                             <Button variant="ghost" size="sm">
                                 <ArrowLeft className="mr-2 h-4 w-4" />
                                 Back to Admins
@@ -51,7 +51,7 @@ export default function AdminShow({ admin }: AdminShowProps) {
                         </div>
                     </div>
                     <div className="flex items-center gap-2">
-                        <Link href={`/admins/${admin.id_admin}/edit`}>
+                        <Link href={`/admin/admins/${admin.id_admin}/edit`}>
                             <Button variant="outline">
                                 <Edit className="mr-2 h-4 w-4" />
                                 Edit

--- a/resources/js/pages/admin/conferences/create.tsx
+++ b/resources/js/pages/admin/conferences/create.tsx
@@ -20,9 +20,9 @@ interface ConferenceCreateProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Conferences Management', href: '/conferences' },
-    { title: 'Create Conference', href: '/conferences/create' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Conferences Management', href: '/admin/conferences' },
+    { title: 'Create Conference', href: '/admin/conferences/create' },
 ];
 
 export default function ConferenceCreate({ admins }: ConferenceCreateProps) {
@@ -65,7 +65,7 @@ export default function ConferenceCreate({ admins }: ConferenceCreateProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/conferences">
+                    <Link href="/admin/conferences">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="h-4 w-4 mr-2" />
                             Back to Conferences
@@ -165,7 +165,7 @@ export default function ConferenceCreate({ admins }: ConferenceCreateProps) {
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Creating...' : 'Create Conference'}
                                         </Button>
-                                        <Link href="/conferences">
+                                        <Link href="/admin/conferences">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/conferences/edit.tsx
+++ b/resources/js/pages/admin/conferences/edit.tsx
@@ -32,8 +32,8 @@ interface ConferenceEditProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Conferences Management', href: '/conferences' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Conferences Management', href: '/admin/conferences' },
     { title: 'Edit Conference', href: '#' },
 ];
 
@@ -80,7 +80,7 @@ export default function ConferenceEdit({ conference, admins }: ConferenceEditPro
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/conferences">
+                    <Link href="/admin/conferences">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="mr-2 h-4 w-4" />
                             Back to Conferences
@@ -175,7 +175,7 @@ export default function ConferenceEdit({ conference, admins }: ConferenceEditPro
                                             <Button type="submit" disabled={processing}>
                                                 {processing ? 'Updating...' : 'Update Conference'}
                                             </Button>
-                                            <Link href="/conferences">
+                                            <Link href="/admin/conferences">
                                                 <Button variant="outline" type="button">
                                                     Cancel
                                                 </Button>

--- a/resources/js/pages/admin/conferences/index.tsx
+++ b/resources/js/pages/admin/conferences/index.tsx
@@ -38,14 +38,14 @@ interface ConferencesIndexProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Conferences Management', href: '/conferences' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Conferences Management', href: '/admin/conferences' },
 ];
 
 export default function ConferencesIndex({ conferences, success }: ConferencesIndexProps) {
     const handleDelete = (conference: Conference) => {
         if (confirm(`Are you sure you want to delete "${conference.title}"?`)) {
-            router.delete(`/conferences/${conference.id_conferences}`);
+            router.delete(`/admin/conferences/${conference.id_conferences}`);
         }
     };
 
@@ -71,7 +71,7 @@ export default function ConferencesIndex({ conferences, success }: ConferencesIn
                             Manage online and offline conferences
                         </p>
                     </div>
-                    <Link href="/conferences/create">
+                    <Link href="/admin/conferences/create">
                         <Button>
                             <Plus className="h-4 w-4 mr-2" />
                             Add Conference
@@ -177,12 +177,12 @@ export default function ConferencesIndex({ conferences, success }: ConferencesIn
                                             {conference.description}
                                         </p>
                                         <div className="flex items-center gap-2">
-                                            <Link href={`/conferences/${conference.id_conferences}`}>
+                                            <Link href={`/admin/conferences/${conference.id_conferences}`}>
                                                 <Button variant="ghost" size="sm">
                                                     <Eye className="h-4 w-4" />
                                                 </Button>
                                             </Link>
-                                            <Link href={`/conferences/${conference.id_conferences}/edit`}>
+                                            <Link href={`/admin/conferences/${conference.id_conferences}/edit`}>
                                                 <Button variant="ghost" size="sm">
                                                     <Edit className="h-4 w-4" />
                                                 </Button>
@@ -205,7 +205,7 @@ export default function ConferencesIndex({ conferences, success }: ConferencesIn
                             <Video className="mx-auto h-12 w-12 text-gray-400 mb-4" />
                             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No conferences found</h3>
                             <p className="text-gray-500 mb-4">Get started by creating your first conference.</p>
-                            <Link href="/conferences/create">
+                            <Link href="/admin/conferences/create">
                                 <Button>
                                     <Plus className="h-4 w-4 mr-2" />
                                     Create Conference

--- a/resources/js/pages/admin/conferences/show.tsx
+++ b/resources/js/pages/admin/conferences/show.tsx
@@ -29,15 +29,15 @@ interface ConferenceShowProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Conferences Management', href: '/conferences' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Conferences Management', href: '/admin/conferences' },
     { title: 'Conference Details', href: '#' },
 ];
 
 export default function ConferenceShow({ conference }: ConferenceShowProps) {
     const handleDelete = () => {
         if (confirm(`Are you sure you want to delete "${conference.title}"?`)) {
-            router.delete(`/conferences/${conference.id_conferences}`);
+            router.delete(`/admin/conferences/${conference.id_conferences}`);
         }
     };
 
@@ -49,7 +49,7 @@ export default function ConferenceShow({ conference }: ConferenceShowProps) {
                 {/* Header */}
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-4">
-                        <Link href="/conferences">
+                        <Link href="/admin/conferences">
                             <Button variant="ghost" size="sm">
                                 <ArrowLeft className="mr-2 h-4 w-4" />
                                 Back to Conferences
@@ -61,7 +61,7 @@ export default function ConferenceShow({ conference }: ConferenceShowProps) {
                         </div>
                     </div>
                     <div className="flex items-center gap-2">
-                        <Link href={`/conferences/${conference.id_conferences}/edit`}>
+                        <Link href={`/admin/conferences/${conference.id_conferences}/edit`}>
                             <Button variant="outline">
                                 <Edit className="mr-2 h-4 w-4" />
                                 Edit

--- a/resources/js/pages/admin/education-careers/create.tsx
+++ b/resources/js/pages/admin/education-careers/create.tsx
@@ -20,9 +20,9 @@ interface EducationCareersCreateProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Careers Management', href: '/careers' }, 
-    { title: 'Create Career', href: '/careers/create' }, 
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Careers Management', href: '/admin/careers' }, 
+    { title: 'Create Career', href: '/admin/careers/create' }, 
 ];
 
 export default function EducationCareersCreate({ admins }: EducationCareersCreateProps) {
@@ -67,7 +67,7 @@ export default function EducationCareersCreate({ admins }: EducationCareersCreat
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/careers">
+                    <Link href="/admin/careers">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="h-4 w-4 mr-2" />
                             Back to Careers
@@ -183,7 +183,7 @@ export default function EducationCareersCreate({ admins }: EducationCareersCreat
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Creating...' : 'Create Career'}
                                         </Button>
-                                        <Link href="/careers">
+                                        <Link href="/admin/careers">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/education-careers/edit.tsx
+++ b/resources/js/pages/admin/education-careers/edit.tsx
@@ -34,8 +34,8 @@ interface EducationCareersEditProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Careers Management', href: '/careers' }, // Ubah ke /careers
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Careers Management', href: '/admin/careers' }, // Ubah ke /careers
     { title: 'Career', href: '#' },
 ];
 
@@ -83,7 +83,7 @@ export default function EducationCareersEdit({ educationCareer, admins }: Educat
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/careers">
+                    <Link href="/admin/careers">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="mr-2 h-4 w-4" />
                             Back to Careers
@@ -195,7 +195,7 @@ export default function EducationCareersEdit({ educationCareer, admins }: Educat
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Updating...' : 'Update Career'}
                                         </Button>
-                                        <Link href="/careers">
+                                        <Link href="/admin/careers">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/education-careers/index.tsx
+++ b/resources/js/pages/admin/education-careers/index.tsx
@@ -40,15 +40,15 @@ interface EducationCareersIndexProps {
 
 // Ubah breadcrumbs
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Careers Management', href: '/careers' }, // Ubah ke /careers
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Careers Management', href: '/admin/careers' }, // Ubah ke /careers
 ];
 
 export default function EducationCareersIndex({ educations, success }: EducationCareersIndexProps) {
     // Ubah handleDelete
     const handleDelete = (education: EducationCareer) => {
         if (confirm(`Are you sure you want to delete "${education.title}"?`)) {
-            router.delete(`/careers/${education.id_education}`);
+            router.delete(`/admin/careers/${education.id_education}`);
         }
     };
 
@@ -64,7 +64,7 @@ export default function EducationCareersIndex({ educations, success }: Education
                         <p className="text-muted-foreground">Manage career content</p>
                     </div>
                     {/* Ubah button Add Career */}
-                    <Link href="/careers/create">
+                    <Link href="/admin/careers/create">
                         <Button>
                             <Plus className="mr-2 h-4 w-4" />
                             Add Career
@@ -123,12 +123,12 @@ export default function EducationCareersIndex({ educations, success }: Education
                                                 <td className="px-6 py-4">{education.admin.username}</td>
                                                 <td className="px-6 py-4">
                                                     <div className="flex items-center gap-2">
-                                                        <Link href={`/careers/${education.id_education}`}>
+                                                        <Link href={`/admin/careers/${education.id_education}`}>
                                                             <Button variant="ghost" size="sm">
                                                                 <Eye className="h-4 w-4" />
                                                             </Button>
                                                         </Link>
-                                                        <Link href={`/careers/${education.id_education}/edit`}>
+                                                        <Link href={`/admin/careers/${education.id_education}/edit`}>
                                                             <Button variant="ghost" size="sm">
                                                                 <Edit className="h-4 w-4" />
                                                             </Button>

--- a/resources/js/pages/admin/education-careers/show.tsx
+++ b/resources/js/pages/admin/education-careers/show.tsx
@@ -30,8 +30,8 @@ interface EducationCareersShowProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Careers Management', href: '/careers' }, // Ubah ke /careers
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Careers Management', href: '/admin/careers' }, // Ubah ke /careers
     { title: 'Career Details', href: '#' },
 ];
 
@@ -39,7 +39,7 @@ export default function EducationCareersShow({ educationCareer }: EducationCaree
     // Ubah handleDelete
     const handleDelete = () => {
         if (confirm(`Are you sure you want to delete "${educationCareer.title}"?`)) {
-            router.delete(`/careers/${educationCareer.id_education}`);
+            router.delete(`/admin/careers/${educationCareer.id_education}`);
         }
     };
 
@@ -51,7 +51,7 @@ export default function EducationCareersShow({ educationCareer }: EducationCaree
                 {/* Header */}
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-4">
-                        <Link href="/careers">
+                        <Link href="/admin/careers">
                             <Button variant="ghost" size="sm">
                                 <ArrowLeft className="mr-2 h-4 w-4" />
                                 Back to Careers
@@ -63,7 +63,7 @@ export default function EducationCareersShow({ educationCareer }: EducationCaree
                         </div>
                     </div>
                     <div className="flex items-center gap-2">
-                        <Link href={`/careers/${educationCareer.id_education}/edit`}>
+                        <Link href={`/admin/careers/${educationCareer.id_education}/edit`}>
                             <Button variant="outline">
                                 <Edit className="mr-2 h-4 w-4" />
                                 Edit

--- a/resources/js/pages/admin/events/create.tsx
+++ b/resources/js/pages/admin/events/create.tsx
@@ -20,9 +20,9 @@ interface EventsCreateProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Events Management', href: '/events' },
-    { title: 'Create Event', href: '/events/create' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Events Management', href: '/admin/events' },
+    { title: 'Create Event', href: '/admin/events/create' },
 ];
 
 export default function EventsCreate({ admins }: EventsCreateProps) {
@@ -65,7 +65,7 @@ export default function EventsCreate({ admins }: EventsCreateProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/events">
+                    <Link href="/admin/events">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="h-4 w-4 mr-2" />
                             Back to Events
@@ -165,7 +165,7 @@ export default function EventsCreate({ admins }: EventsCreateProps) {
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Creating...' : 'Create Event'}
                                         </Button>
-                                        <Link href="/events">
+                                        <Link href="/admin/events">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/events/edit.tsx
+++ b/resources/js/pages/admin/events/edit.tsx
@@ -32,8 +32,8 @@ interface EventsEditProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Events Management', href: '/events' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Events Management', href: '/admin/events' },
     { title: 'Edit Event', href: '#' },
 ];
 
@@ -80,7 +80,7 @@ export default function EventsEdit({ event, admins }: EventsEditProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/events">
+                    <Link href="/admin/events">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="mr-2 h-4 w-4" />
                             Back to Events
@@ -176,7 +176,7 @@ export default function EventsEdit({ event, admins }: EventsEditProps) {
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Updating...' : 'Update Event'}
                                         </Button>
-                                        <Link href="/events">
+                                        <Link href="/admin/events">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/events/index.tsx
+++ b/resources/js/pages/admin/events/index.tsx
@@ -37,14 +37,14 @@ interface EventsIndexProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Events Management', href: '/events' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Events Management', href: '/admin/events' },
 ];
 
 export default function EventsIndex({ events, success }: EventsIndexProps) {
     const handleDelete = (event: Event) => {
         if (confirm(`Are you sure you want to delete "${event.title}"?`)) {
-            router.delete(`/events/${event.id_events}`);
+            router.delete(`/admin/events/${event.id_events}`);
         }
     };
 
@@ -70,7 +70,7 @@ export default function EventsIndex({ events, success }: EventsIndexProps) {
                             Manage events, conferences, and activities
                         </p>
                     </div>
-                    <Link href="/events/create">
+                    <Link href="/admin/events/create">
                         <Button>
                             <Plus className="h-4 w-4 mr-2" />
                             Add Event
@@ -176,12 +176,12 @@ export default function EventsIndex({ events, success }: EventsIndexProps) {
                                             {event.description}
                                         </p>
                                         <div className="flex items-center gap-2">
-                                            <Link href={`/events/${event.id_events}`}>
+                                            <Link href={`/admin/events/${event.id_events}`}>
                                                 <Button variant="ghost" size="sm">
                                                     <Eye className="h-4 w-4" />
                                                 </Button>
                                             </Link>
-                                            <Link href={`/events/${event.id_events}/edit`}>
+                                            <Link href={`/admin/events/${event.id_events}/edit`}>
                                                 <Button variant="ghost" size="sm">
                                                     <Edit className="h-4 w-4" />
                                                 </Button>
@@ -204,7 +204,7 @@ export default function EventsIndex({ events, success }: EventsIndexProps) {
                             <MapPin className="mx-auto h-12 w-12 text-gray-400 mb-4" />
                             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No events found</h3>
                             <p className="text-gray-500 mb-4">Get started by creating your first event.</p>
-                            <Link href="/events/create">
+                            <Link href="/admin/events/create">
                                 <Button>
                                     <Plus className="h-4 w-4 mr-2" />
                                     Create Event

--- a/resources/js/pages/admin/events/show.tsx
+++ b/resources/js/pages/admin/events/show.tsx
@@ -29,15 +29,15 @@ interface EventsShowProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Events Management', href: '/events' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Events Management', href: '/admin/events' },
     { title: 'Event Details', href: '#' },
 ];
 
 export default function EventsShow({ event }: EventsShowProps) {
     const handleDelete = () => {
         if (confirm(`Are you sure you want to delete "${event.title}"?`)) {
-            router.delete(`/events/${event.id_events}`);
+            router.delete(`/admin/events/${event.id_events}`);
         }
     };
 
@@ -49,7 +49,7 @@ export default function EventsShow({ event }: EventsShowProps) {
                 {/* Header */}
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-4">
-                        <Link href="/events">
+                        <Link href="/admin/events">
                             <Button variant="ghost" size="sm">
                                 <ArrowLeft className="mr-2 h-4 w-4" />
                                 Back to Events
@@ -61,7 +61,7 @@ export default function EventsShow({ event }: EventsShowProps) {
                         </div>
                     </div>
                     <div className="flex items-center gap-2">
-                        <Link href={`/events/${event.id_events}/edit`}>
+                        <Link href={`/admin/events/${event.id_events}/edit`}>
                             <Button variant="outline">
                                 <Edit className="mr-2 h-4 w-4" />
                                 Edit

--- a/resources/js/pages/admin/journal/create.tsx
+++ b/resources/js/pages/admin/journal/create.tsx
@@ -20,9 +20,9 @@ interface JournalCreateProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Journal Management', href: '/journal' },
-    { title: 'Create Journal', href: '/journal/create' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Journal Management', href: '/admin/journal' },
+    { title: 'Create Journal', href: '/admin/journal/create' },
 ];
 
 export default function JournalCreate({ admins }: JournalCreateProps) {
@@ -63,7 +63,7 @@ export default function JournalCreate({ admins }: JournalCreateProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/journal">
+                    <Link href="/admin/journal">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="h-4 w-4 mr-2" />
                             Back to Journal
@@ -132,7 +132,7 @@ export default function JournalCreate({ admins }: JournalCreateProps) {
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Creating...' : 'Create Journal'}
                                         </Button>
-                                        <Link href="/journal">
+                                        <Link href="/admin/journal">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/journal/edit.tsx
+++ b/resources/js/pages/admin/journal/edit.tsx
@@ -30,8 +30,8 @@ interface JournalEditProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Journal Management', href: '/journal' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Journal Management', href: '/admin/journal' },
     { title: 'Edit Journal', href: '#' },
 ];
 
@@ -76,7 +76,7 @@ export default function JournalEdit({ journal, admins }: JournalEditProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/journal">
+                    <Link href="/admin/journal">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="mr-2 h-4 w-4" />
                             Back to Journal
@@ -140,7 +140,7 @@ export default function JournalEdit({ journal, admins }: JournalEditProps) {
                                             <Button type="submit" disabled={processing}>
                                                 {processing ? 'Updating...' : 'Update Journal'}
                                             </Button>
-                                            <Link href="/journal">
+                                            <Link href="/admin/journal">
                                                 <Button variant="outline" type="button">
                                                     Cancel
                                                 </Button>

--- a/resources/js/pages/admin/journal/index.tsx
+++ b/resources/js/pages/admin/journal/index.tsx
@@ -36,14 +36,14 @@ interface JournalsIndexProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Journal Management', href: '/journal' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Journal Management', href: '/admin/journal' },
 ];
 
 export default function JournalsIndex({ journals, success }: JournalsIndexProps) {
     const handleDelete = (journal: Journal) => {
         if (confirm(`Are you sure you want to delete "${journal.title}"?`)) {
-            router.delete(`/journal/${journal.id_journal}`);
+            router.delete(`/admin/journal/${journal.id_journal}`);
         }
     };
 
@@ -60,7 +60,7 @@ export default function JournalsIndex({ journals, success }: JournalsIndexProps)
                             Manage journal entries and publications
                         </p>
                     </div>
-                    <Link href="/journal/create">
+                    <Link href="/admin/journal/create">
                         <Button>
                             <Plus className="h-4 w-4 mr-2" />
                             Add Journal
@@ -146,12 +146,12 @@ export default function JournalsIndex({ journals, success }: JournalsIndexProps)
                                 </CardHeader>
                                 <CardContent className="pt-0">
                                     <div className="flex items-center gap-2">
-                                        <Link href={`/journal/${journal.id_journal}`}>
+                                        <Link href={`/admin/journal/${journal.id_journal}`}>
                                             <Button variant="ghost" size="sm">
                                                 <Eye className="h-4 w-4" />
                                             </Button>
                                         </Link>
-                                        <Link href={`/journal/${journal.id_journal}/edit`}>
+                                        <Link href={`/admin/journal/${journal.id_journal}/edit`}>
                                             <Button variant="ghost" size="sm">
                                                 <Edit className="h-4 w-4" />
                                             </Button>
@@ -173,7 +173,7 @@ export default function JournalsIndex({ journals, success }: JournalsIndexProps)
                             <BookOpen className="mx-auto h-12 w-12 text-gray-400 mb-4" />
                             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No journals found</h3>
                             <p className="text-gray-500 mb-4">Get started by creating your first journal entry.</p>
-                            <Link href="/journal/create">
+                            <Link href="/admin/journal/create">
                                 <Button>
                                     <Plus className="h-4 w-4 mr-2" />
                                     Create Journal

--- a/resources/js/pages/admin/journal/show.tsx
+++ b/resources/js/pages/admin/journal/show.tsx
@@ -27,15 +27,15 @@ interface JournalShowProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'Journal Management', href: '/journal' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'Journal Management', href: '/admin/journal' },
     { title: 'Journal Details', href: '#' },
 ];
 
 export default function JournalShow({ journal }: JournalShowProps) {
     const handleDelete = () => {
         if (confirm(`Are you sure you want to delete "${journal.title}"?`)) {
-            router.delete(`/journal/${journal.id_journal}`);
+            router.delete(`/admin/journal/${journal.id_journal}`);
         }
     };
 
@@ -47,7 +47,7 @@ export default function JournalShow({ journal }: JournalShowProps) {
                 {/* Header */}
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-4">
-                        <Link href="/journal">
+                        <Link href="/admin/journal">
                             <Button variant="ghost" size="sm">
                                 <ArrowLeft className="mr-2 h-4 w-4" />
                                 Back to Journal
@@ -59,7 +59,7 @@ export default function JournalShow({ journal }: JournalShowProps) {
                         </div>
                     </div>
                     <div className="flex items-center gap-2">
-                        <Link href={`/journal/${journal.id_journal}/edit`}>
+                        <Link href={`/admin/journal/${journal.id_journal}/edit`}>
                             <Button variant="outline">
                                 <Edit className="mr-2 h-4 w-4" />
                                 Edit

--- a/resources/js/pages/admin/news/create.tsx
+++ b/resources/js/pages/admin/news/create.tsx
@@ -20,9 +20,9 @@ interface NewsCreateProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'News Management', href: '/news' },
-    { title: 'Create News', href: '/news/create' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'News Management', href: '/admin/news' },
+    { title: 'Create News', href: '/admin/news/create' },
 ];
 
 export default function NewsCreate({ admins }: NewsCreateProps) {
@@ -66,7 +66,7 @@ export default function NewsCreate({ admins }: NewsCreateProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/news">
+                    <Link href="/admin/news">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="h-4 w-4 mr-2" />
                             Back to News
@@ -183,7 +183,7 @@ export default function NewsCreate({ admins }: NewsCreateProps) {
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Creating...' : 'Create News'}
                                         </Button>
-                                        <Link href="/news">
+                                        <Link href="/admin/news">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/news/edit.tsx
+++ b/resources/js/pages/admin/news/edit.tsx
@@ -34,8 +34,8 @@ interface NewsEditProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'News Management', href: '/news' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'News Management', href: '/admin/news' },
     { title: 'Edit News', href: '#' },
 ];
 
@@ -83,7 +83,7 @@ export default function NewsEdit({ news, admins }: NewsEditProps) {
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 {/* Header */}
                 <div className="flex items-center gap-4">
-                    <Link href="/news">
+                    <Link href="/admin/news">
                         <Button variant="ghost" size="sm">
                             <ArrowLeft className="mr-2 h-4 w-4" />
                             Back to News
@@ -195,7 +195,7 @@ export default function NewsEdit({ news, admins }: NewsEditProps) {
                                         <Button type="submit" disabled={processing}>
                                             {processing ? 'Updating...' : 'Update News'}
                                         </Button>
-                                        <Link href="/news">
+                                        <Link href="/admin/news">
                                             <Button variant="outline" type="button">
                                                 Cancel
                                             </Button>

--- a/resources/js/pages/admin/news/index.tsx
+++ b/resources/js/pages/admin/news/index.tsx
@@ -39,14 +39,14 @@ interface NewsIndexProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'News Management', href: '/news' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'News Management', href: '/admin/news' },
 ];
 
 export default function NewsIndex({ news, success }: NewsIndexProps) {
     const handleDelete = (newsItem: NewsItem) => {
         if (confirm(`Are you sure you want to delete "${newsItem.title}"?`)) {
-            router.delete(`/news/${newsItem.id_news}`);
+            router.delete(`/admin/news/${newsItem.id_news}`);
         }
     };
 
@@ -63,7 +63,7 @@ export default function NewsIndex({ news, success }: NewsIndexProps) {
                             Manage news articles and publications
                         </p>
                     </div>
-                    <Link href="/news/create">
+                    <Link href="/admin/news/create">
                         <Button>
                             <Plus className="h-4 w-4 mr-2" />
                             Add News
@@ -186,12 +186,12 @@ export default function NewsIndex({ news, success }: NewsIndexProps) {
                                                 </td>
                                                 <td className="px-6 py-4">
                                                     <div className="flex items-center gap-2">
-                                                        <Link href={`/news/${newsItem.id_news}`}>
+                                                        <Link href={`/admin/news/${newsItem.id_news}`}>
                                                             <Button variant="ghost" size="sm">
                                                                 <Eye className="h-4 w-4" />
                                                             </Button>
                                                         </Link>
-                                                        <Link href={`/news/${newsItem.id_news}/edit`}>
+                                                        <Link href={`/admin/news/${newsItem.id_news}/edit`}>
                                                             <Button variant="ghost" size="sm">
                                                                 <Edit className="h-4 w-4" />
                                                             </Button>

--- a/resources/js/pages/admin/news/show.tsx
+++ b/resources/js/pages/admin/news/show.tsx
@@ -30,15 +30,15 @@ interface NewsShowProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
-    { title: 'News Management', href: '/news' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
+    { title: 'News Management', href: '/admin/news' },
     { title: 'News Details', href: '#' },
 ];
 
 export default function NewsShow({ news }: NewsShowProps) {
     const handleDelete = () => {
         if (confirm(`Are you sure you want to delete "${news.title}"?`)) {
-            router.delete(`/news/${news.id_news}`);
+            router.delete(`/admin/news/${news.id_news}`);
         }
     };
 
@@ -50,7 +50,7 @@ export default function NewsShow({ news }: NewsShowProps) {
                 {/* Header */}
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-4">
-                        <Link href="/news">
+                        <Link href="/admin/news">
                             <Button variant="ghost" size="sm">
                                 <ArrowLeft className="mr-2 h-4 w-4" />
                                 Back to News
@@ -62,7 +62,7 @@ export default function NewsShow({ news }: NewsShowProps) {
                         </div>
                     </div>
                     <div className="flex items-center gap-2">
-                        <Link href={`/news/${news.id_news}/edit`}>
+                        <Link href={`/admin/news/${news.id_news}/edit`}>
                             <Button variant="outline">
                                 <Edit className="mr-2 h-4 w-4" />
                                 Edit

--- a/resources/js/pages/admin/pencarian-members/index.tsx
+++ b/resources/js/pages/admin/pencarian-members/index.tsx
@@ -42,7 +42,7 @@ interface PencarianMemberIndexProps {
 }
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Dashboard', href: '/dashboard' },
+    { title: 'Dashboard', href: '/admin/dashboard' },
     { title: 'Member Management', href: '/pencarian-members' },
 ];
 

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -29,7 +29,7 @@ interface DashboardProps {
 const breadcrumbs: BreadcrumbItem[] = [
     {
         title: 'Dashboard',
-        href: '/dashboard',
+        href: '/admin/dashboard',
     },
 ];
 
@@ -40,7 +40,7 @@ export default function Dashboard({ counts, recentActivity, latestPosts = [] }: 
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
                 {/* Stats Cards */}
                 <div className="grid gap-4 md:grid-cols-4">
-                    <Link href="/news" className="no-underline">
+                    <Link href="/admin/news" className="no-underline">
                         <Card >
                             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                                 <CardTitle className="text-sm font-medium">Total News</CardTitle>
@@ -53,7 +53,7 @@ export default function Dashboard({ counts, recentActivity, latestPosts = [] }: 
                         </Card>
                     </Link>
 
-                    <Link href="/events" className="no-underline">
+                    <Link href="/admin/events" className="no-underline">
                         <Card>
                             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                                 <CardTitle className="text-sm font-medium">Total Events</CardTitle>
@@ -66,7 +66,7 @@ export default function Dashboard({ counts, recentActivity, latestPosts = [] }: 
                         </Card>
                     </Link>
 
-                    <Link href="/conferences" className="no-underline">
+                    <Link href="/admin/conferences" className="no-underline">
                         <Card>
                             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                                 <CardTitle className="text-sm font-medium">Conferences</CardTitle>
@@ -79,7 +79,7 @@ export default function Dashboard({ counts, recentActivity, latestPosts = [] }: 
                         </Card>
                     </Link>
 
-                    <Link href="/careers" className="no-underline">
+                    <Link href="/admin/careers" className="no-underline">
                         <Card>
                             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                                 <CardTitle className="text-sm font-medium">Careers</CardTitle>

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,7 +49,7 @@ Route::get('landing/journals', function () {
 
 Route::middleware(['auth', 'verified'])->group(function () {
     // Dashboard
-    Route::get('dashboard', function () {
+    Route::get('admin/dashboard', function () {
         // Collect latest news
         $latestNews = \App\Models\News::select('id_news as id', 'title', \DB::raw("'news' as category"), 'created_at as date')
             ->orderBy('created_at', 'desc')
@@ -135,71 +135,44 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ]);
     })->name('dashboard');
 
-    // Admin Management Routes
-    Route::resource('admins', AdminController::class);
-    // Direct Inertia rendering route for admins
-    Route::get('admin/admins', function () {
-        $admins = \App\Models\Admin::latest()->paginate(10);
-        return Inertia::render('admin/admins/index', ['admins' => $admins]);
-    })->name('admin.admins');
-
     // Content Management Routes with Inertia rendering
-    Route::resource('about-us', AboutUsController::class);
-    Route::get('admin/about-us', function () {
-    $aboutUs = \App\Models\AboutUs::with('admin')->latest()->paginate(10);
-        return Inertia::render('admin/about-us/index', ['aboutUs' => $aboutUs]);
-    })->name('admin.about-us');
-
-    Route::resource('news', NewsController::class);
-    Route::get('admin/news', function () {
-        $news = \App\Models\News::with('admin')->latest()->paginate(10);
-        return Inertia::render('admin/news/index', ['news' => $news]);
-    })->name('admin.news');
-
-    Route::resource('journal', JournalController::class);
-    Route::get('admin/journal', function () {
-        $journals = \App\Models\Journal::with('admin')->latest()->paginate(10);
-        return Inertia::render('admin/journal/index', ['journals' => $journals]);
-    })->name('admin.journal');
-
-    Route::resource('events', EventsController::class);
-    Route::get('admin/events', function () {
-        $events = \App\Models\Events::with('admin')->latest()->paginate(10);
-        return Inertia::render('admin/events/index', ['events' => $events]);
-    })->name('admin.events');
-
-    Route::resource('conferences', ConferencesController::class);
-    Route::get('admin/conferences', function () {
-        $conferences = \App\Models\Conferences::with('admin')->latest()->paginate(10);
-        return Inertia::render('admin/conferences/index', ['conferences' => $conferences]);
-    })->name('admin.conferences');
-
-    Route::resource('careers', EducationAndCareersController::class)->parameters([
-        'careers' => 'educationCareer'
-    ]);
-    Route::get('admin/education-careers', function () {
-        $educations = \App\Models\EducationAndCareers::with('admin')->latest()->paginate(10);
-        return Inertia::render('admin/education-careers/index', ['educations' => $educations]);
-    })->name('admin.education-careers');
-
-    // User Management Routes
-    Route::resource('pencarian-members', PencarianMemberController::class);
-    Route::get('admin/pencarian-members', function () {
-        $members = \App\Models\PencarianMember::with('user')->latest()->paginate(10);
-        return Inertia::render('admin/pencarian-members/index', ['members' => $members]);
-    })->name('admin.pencarian-members');
-
-    Route::resource('jenis-mitra', JenisMitraController::class);
-    Route::get('admin/jenis-mitra', function () {
-        $mitras = \App\Models\JenisMitra::with('user')->latest()->paginate(10);
-        return Inertia::render('admin/jenis-mitra/index', ['mitras' => $mitras]);
-    })->name('admin.jenis-mitra');
-
-    Route::resource('contacts', ContactController::class);
-    Route::get('admin/contacts', function () {
-        $contacts = \App\Models\Contact::with(['pencarianMember', 'jenisMitra'])->latest()->paginate(10);
-        return Inertia::render('admin/contacts/index', ['contacts' => $contacts]);
-    })->name('admin.contacts');
+    Route::prefix('admin')->group(function() {
+        // About Us routes
+        Route::get('/about-us', [AboutUsController::class, 'index'])->name('about-us.index');
+        Route::post('/about-us', [AboutUsController::class, 'store'])->name('about-us.store');
+        
+        // News routes
+        Route::resource('news', NewsController::class)->names([
+            'index' => 'news.index',
+            'create' => 'news.create',
+            'store' => 'news.store',
+            'show' => 'news.show',
+            'edit' => 'news.edit',
+            'update' => 'news.update',
+            'destroy' => 'news.destroy',
+        ]);
+        
+        // Journal routes
+        Route::resource('journal', JournalController::class);
+        
+        // Events routes
+        Route::resource('events', EventsController::class);
+        
+        // Conferences routes
+        Route::resource('conferences', ConferencesController::class);
+        
+        // Careers routes
+        Route::resource('careers', EducationAndCareersController::class)
+            ->parameters(['careers' => 'educationCareer']);
+            
+        // User Management Routes
+        Route::resource('pencarian-members', PencarianMemberController::class);
+        Route::resource('jenis-mitra', JenisMitraController::class);
+        Route::resource('contacts', ContactController::class);
+        
+        // Admin Management Routes
+        Route::resource('admins', AdminController::class);
+    });
 });
 
 require __DIR__ . '/settings.php';


### PR DESCRIPTION
- Updated breadcrumbs and navigation links in various admin pages (conferences, education careers, events, journal, news) to point to the new /admin routes.
- Changed the dashboard route to /admin/dashboard.
- Refactored web.php to group admin routes under a single prefix for better organization and clarity.